### PR TITLE
docs: remove mpnId from manifest

### DIFF
--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -25,7 +25,6 @@ You must provide the following information in a manifest file (json format) that
     "name": "My Name",
     "websiteUrl": "https://website.com/",
     "privacyUrl": "https://website.com/privacy",
-    "mpnId": "1234567890"
   },
   "name": {
     "short": "App Name",


### PR DESCRIPTION
mpnId key it's not related to Wazo.