### PR TITLE
Fix softphone and links

### DIFF
--- a/documentation/docs/installation.md
+++ b/documentation/docs/installation.md
@@ -6,6 +6,20 @@ displayed_sidebar: installSidebar
 
 Let's install the **Wazo EUC Plugins SDK in less than 5 minutes**.
 
+## Prerequisites
+
+Before starting, we suggest being familiar with the following subjects to ease your experience.
+
+- HMTL & CSS
+- JSON
+- Javascript language
+  - [async](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function)/[await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await)
+- Our [Developers Center](https://developers.wazo.io/)
+
+:::info
+**New to web technologies?** We suggest this guide: [Getting started with the web](https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web).
+:::
+
 ## Using a Package Manager
 
 You can install our SDK with your favorite package manager in the following ways:

--- a/documentation/docs/plugins/portal-examples.md
+++ b/documentation/docs/plugins/portal-examples.md
@@ -7,18 +7,16 @@ displayed_sidebar: pluginsSidebar
 ### Adding a Tab in the PBX Dashboard Page
 
 ```js
-(async () => {
-  await app.initialize();
-  const context = app.getContext();
+await app.initialize();
+const context = app.getContext();
 
-  document.getElementById('name').innerHTML = context.app.extra.record.auth.username;
-})();
+document.getElementById('name').innerHTML = context.app.extra.record.auth.username;
 ```
 
-[👀 See full example](https://github.com/wazo-communication/euc-plugins-js-sdk/tree/master/documentation/static/examples/portal/pbx-dashboard-tab)
+[👀 View source code](https://github.com/wazo-communication/euc-plugins-js-sdk/tree/master/documentation/static/examples/portal/pbx-dashboard-tab)
 
 <a class="try-it button button--secondary button--lg" href="https://portal.wazo.io/?manifestUrl=https://wazo-communication.github.io/euc-plugins-js-sdk/examples/portal/pbx-dashboard-tab/manifest.json" target="_blank">
-    📊 Add a tab in the PBX dashboard
+    📊 Try custom tab for PBX Dashboard
 </a>
 
 ### Adding a New Tab in the PBX User Edition Form
@@ -29,17 +27,15 @@ You may want to create your own page/form in a PBX form.
 See [This section](./portal#adding-tabs-in-a-form) for more information.
 
 ```js
-(async () => {
-  await app.initialize();
-  const context = app.getContext();
+await app.initialize();
+const context = app.getContext();
 
-  // You'll find information about the PBX user in `context.app.extra.record`;
-  document.getElementById('name').innerHTML = context.app.extra.record.auth.username;
-})();
+// You'll find information about the PBX user in `context.app.extra.record`;
+document.getElementById('name').innerHTML = context.app.extra.record.auth.username;
 ```
 
-[👀 See full example](https://github.com/wazo-communication/euc-plugins-js-sdk/tree/master/documentation/static/examples/portal/pbx-user-form-tab)
+[👀 View source code](https://github.com/wazo-communication/euc-plugins-js-sdk/tree/master/documentation/static/examples/portal/pbx-user-form-tab)
 
 <a class="try-it button button--secondary button--lg" href="https://portal.wazo.io/?manifestUrl=https://wazo-communication.github.io/euc-plugins-js-sdk/examples/portal/pbx-user-form-tab/manifest.json" target="_blank">
-    👨‍🦰 Add a tab in the PBX user form !
+    👨‍🦰 Try custom tab for PBX user's form
 </a>

--- a/documentation/docs/plugins/wda-examples.md
+++ b/documentation/docs/plugins/wda-examples.md
@@ -16,13 +16,11 @@ app.onAppUnLoaded(tabId => {
 })
 
 // tab.js
-(async () => {
-  await app.initialize();
-  app.closeLeftPanel();
-  app.changeNavBarColor('#8e6a3a');
-})();
+await app.initialize();
+app.closeLeftPanel();
+app.changeNavBarColor('#8e6a3a');
 ```
-[👀 See full example](https://github.com/wazo-communication/euc-plugins-js-sdk/tree/master/documentation/static/examples/wda/sidebar-color)
+[👀 View source code](https://github.com/wazo-communication/euc-plugins-js-sdk/tree/master/documentation/static/examples/wda/sidebar-color)
 
 <a class="try-it button button--secondary button--lg" href="https://app.wazo.io/?manifestUrl=https://wazo-communication.github.io/euc-plugins-js-sdk/examples/wda/sidebar-color/manifest.json" target="_blank">
     🎨 Try changing the sidebar !
@@ -43,7 +41,7 @@ app.onCallIncoming = async call => {
 
 await app.initialize();
 ```
-[👀 See full example](https://github.com/wazo-communication/euc-plugins-js-sdk/tree/master/documentation/static/examples/wda/incoming-call-modal)
+[👀 View source code](https://github.com/wazo-communication/euc-plugins-js-sdk/tree/master/documentation/static/examples/wda/incoming-call-modal)
 
 <a class="try-it button button--secondary button--lg" href="https://app.wazo.io/?manifestUrl=https://wazo-communication.github.io/euc-plugins-js-sdk/examples/wda/incoming-call-modal/manifest.json" target="_blank">
     ☎️ Try the incoming call modal !
@@ -71,7 +69,7 @@ app.onBackgroundMessage = msg => {
 app.initialize();
 ```
 
-[👀 See full example](https://github.com/wazo-communication/euc-plugins-js-sdk/tree/master/documentation/static/examples/wda/iframe-bg-messaging)
+[👀 View source code](https://github.com/wazo-communication/euc-plugins-js-sdk/tree/master/documentation/static/examples/wda/iframe-bg-messaging)
 
 <a class="try-it button button--secondary button--lg" href="https://app.wazo.io/?manifestUrl=https://wazo-communication.github.io/euc-plugins-js-sdk/examples/wda/iframe-bg-messaging/manifest.json" target="_blank">
     📣 Try messaging background ↔️ tab
@@ -94,7 +92,7 @@ app.initialize();
 ]
 ```
 
-[👀 See full example](https://github.com/wazo-communication/euc-plugins-js-sdk/tree/master/documentation/static/examples/wda/settings-menu)
+[👀 View source code](https://github.com/wazo-communication/euc-plugins-js-sdk/tree/master/documentation/static/examples/wda/settings-menu)
 
 <a class="try-it button button--secondary button--lg" href="https://app.wazo.io/?manifestUrl=https://wazo-communication.github.io/euc-plugins-js-sdk/examples/wda/settings-menu/manifest.json" target="_blank">
     📣 Try adding a new settings menu
@@ -139,7 +137,7 @@ app.onCallAnswered = (call) => {
   }
 };
 ```
-[👀 See full example](https://github.com/wazo-communication/euc-plugins-js-sdk/tree/master/documentation/static/examples/wda/video-pip)
+[👀 View source code](https://github.com/wazo-communication/euc-plugins-js-sdk/tree/master/documentation/static/examples/wda/video-pip)
 
 <a class="try-it button button--secondary button--lg" href="https://app.wazo.io/?manifestUrl=https://wazo-communication.github.io/euc-plugins-js-sdk/examples/wda/video-pip/manifest.json" target="_blank">
     🎥 Try displaying videos as miniatures in a video call
@@ -161,7 +159,7 @@ setTimeout(() => {
 }, 2000);
 ```
 
-[👀 See full example](https://github.com/wazo-communication/euc-plugins-js-sdk/tree/master/documentation/static/examples/wda/configure-sounds)
+[👀 View source code](https://github.com/wazo-communication/euc-plugins-js-sdk/tree/master/documentation/static/examples/wda/configure-sounds)
 
 <a class="try-it button button--secondary button--lg" href="https://app.wazo.io/?manifestUrl=https://wazo-communication.github.io/euc-plugins-js-sdk/examples/wda/configure-sounds/manifest.json" target="_blank">
     🎺 Try configuring the application sounds

--- a/documentation/docs/softphone/examples.md
+++ b/documentation/docs/softphone/examples.md
@@ -4,6 +4,8 @@ displayed_sidebar: softphoneSidebar
 
 # Softphone Examples
 
+import '../../src/softphone-example.js';
+
 ## Displaying the softphone
 
 Please refer to the [Installation page](../installation) for information on how to import the Softphone SDK.
@@ -16,7 +18,6 @@ softphone.show();
     🚀 Display the Softphone
 </a>
 
-import '../../src/softphone-example.js';
 
 ## Hiding the softphone
 

--- a/documentation/src/components/HomepageFeatures/index.tsx
+++ b/documentation/src/components/HomepageFeatures/index.tsx
@@ -13,7 +13,7 @@ const FeatureList: FeatureItem[] = [
   {
     title: 'Web and Desktop application',
     Svg: require('@site/static/img/wda.svg').default,
-    link: './docs/web-desktop-application',
+    link: './docs/plugins/web-desktop-application',
     description: (
       <>
         Add tabs, icons, new pages and lot of new feature to your Web and Desktop app.
@@ -23,7 +23,7 @@ const FeatureList: FeatureItem[] = [
   },{
     title: 'Mobile application',
     Svg: require('@site/static/img/mobile.svg').default,
-    link: './docs/mobile',
+    link: './docs/plugins/mobile',
     description: (
       <>
         Create new tab to display your own contact and pilot the Wazo Mobile Application.
@@ -32,7 +32,7 @@ const FeatureList: FeatureItem[] = [
   },{
     title: 'Portal',
     Svg: require('@site/static/img/portal.svg').default,
-    link: './docs/portal',
+    link: './docs/plugins/portal',
     description: (
       <>
         Customize the Wazo Portal to add new tabs and menu items. Add your own dashboard and add more values to your clients.
@@ -42,7 +42,7 @@ const FeatureList: FeatureItem[] = [
   {
     title: 'Softphone',
     Svg: require('@site/static/img/softphone.svg').default,
-    link: './docs/softphone',
+    link: './docs/softphone/introduction',
     description: (
       <>
         Enhance your application with a Softphone that you can embed and control with ease.

--- a/documentation/src/softphone-example.js
+++ b/documentation/src/softphone-example.js
@@ -349,12 +349,10 @@ if (typeof window !== "undefined") {
 
   global.removeSoftphone = () => {
     softphone.remove();
+    document.querySelector('#minimize-button')?.remove();
+    document.querySelector('#maximize-button')?.remove();
   };
 
   let defaultServer = typeof localStorage !== 'undefined' ? localStorage.getItem('softphone-server') || 'my-server' : 'my-server';
   let displayed = false;
-
-  initSoftphone();
 }
-
-

--- a/documentation/src/softphone-module.js
+++ b/documentation/src/softphone-module.js
@@ -1,4 +1,9 @@
-export function onRouteDidUpdate({ location }) {
+export function onRouteDidUpdate({ location, previousLocation }) {
+  // Don't update if hash have changed, but still same page
+  if(location.pathname === previousLocation?.pathname) {
+    return;
+  }
+
   // We have to call `initButtons` each time a user goes to the `softphone-example` page.
   if (location.pathname.indexOf('softphone/examples') !== -1) {
     initButtons();


### PR DESCRIPTION
## Summary of changes

- Fix softphone example glitches
- Fix homepage broken links
- Remove `async` wrapper in examples
- Add prerequisites in the SDK introduction